### PR TITLE
Fix initialize deprecation warning in Ember 2.1

### DIFF
--- a/app/initializers/clock.js
+++ b/app/initializers/clock.js
@@ -2,7 +2,8 @@ import Clock from '../services/clock';
 
 export default {
   name: 'clock',
-  initialize: function(container, app) {
+  initialize: function() {
+    var app = arguments[1] || arguments[0];
     app.register('clock:main', Clock);
     app.inject('controller', 'clock', 'clock:main');
     app.inject('component', 'clock', 'clock:main');


### PR DESCRIPTION
http://emberjs.com/deprecations/v2.x/#toc_initializer-arity :)

This should get rid of the warning, but also keep compatibility with older versions of Ember.

EDIT: Ah, I didn't see your `upgrade` branch. This shouldn't be necessary when that gets released. :+1: 